### PR TITLE
Added definition file

### DIFF
--- a/AssetBundleManager.asmdef
+++ b/AssetBundleManager.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "AssetBundleManager"
+}

--- a/AssetBundleManager.asmdef.meta
+++ b/AssetBundleManager.asmdef.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5a4daf6a9918212448dccc339c64a061
+timeCreated: 1522942122
+licenseType: Pro
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
To improve compilation time in the most recent versions of Unity, it's adviced to use definition files. The Asset Bundle Browser already implements this.